### PR TITLE
Deprecation warning for plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Switched to pytest for unit testing
   - Removes python 3.4 testing from Travis
   - Adds manual install of pandas / xarray to Travis workflow to fix setup
+  - Add deprecation warning to plot_alt_lat
 
 ## [0.1.2] - 2019-07-02
 - Patch to fix loading of unformatted output files.

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -366,7 +366,7 @@ class Model(object):
         warnings.warn(' '.join(["Model.plot_lat_alt is deprecated and will be",
                                 "removed in a future version. ",
                                 "Use sami2py_vis instead"]),
-                  DeprecationWarning)
+                      DeprecationWarning)
 
         fig = plt.gcf()
         plt.pcolor(self.data['glat'], self.data['zalt'],

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -361,9 +361,14 @@ class Model(object):
             0: H+, 1: O+, 2: NO+, 3: O2+, 4: He+, 5: N2+, 6: N+
         """
         import matplotlib.pyplot as plt
+        import warnings
+
+        warnings.warn(' '.join(["Model.plot_lat_alt is deprecated and will be",
+                                "removed in a future version. ",
+                                "Use sami2py_vis instead"]),
+                  DeprecationWarning)
 
         fig = plt.gcf()
-
         plt.pcolor(self.data['glat'], self.data['zalt'],
                    self.data['deni'][:, :, species, time_step])
         plt.xlabel('Geo Lat (deg)')


### PR DESCRIPTION
# Description

Since plotting will be handled by sami2py_vis (sami2plot?), the plot_alt_lat function is not needed here.  Adding a deprecation warning.

## Type of change

- Deprecation warning

# How Has This Been Tested?

n/a

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
