### PR TITLE
BUG: Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bugs fixed
   - Fix for windows directories
   - New directory structure in .sami2py adds virtual environment flexibility
+  - Fixed a bug in feedback when there are no files to move
 
 ## [0.1.2] - 2019-07-02
 - Patch to fix loading of unformatted output files.

--- a/sami2py/_core.py
+++ b/sami2py/_core.py
@@ -401,5 +401,5 @@ def _archive_model(path, clean, fejer, fmtout, outn):
                 shutil.move(list_file, os.path.join(path, list_file))
             else:
                 shutil.copyfile(list_file, os.path.join(path, list_file))
-        else:
-            print('No files to move!')
+    else:
+        print('No files to move!')

--- a/sami2py/_core.py
+++ b/sami2py/_core.py
@@ -384,22 +384,19 @@ def _archive_model(path, clean, fejer, fmtout, outn):
         # Add ExB file to list
         filelist.append('exb.inp')
 
-    if os.path.isfile(filelist[0]):
-        try:
-            os.stat(path)
-        except FileNotFoundError:
-            os.makedirs(path)
+    try:
+        os.stat(path)
+    except FileNotFoundError:
+        os.makedirs(path)
 
-        hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
-        with open(os.path.join(path, 'version.txt'), 'w+') as f:
-            f.write('sami2py v' + __version__ + '\n')
-            f.write('short hash ' + hash.decode("utf-8"))
+    hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
+    with open(os.path.join(path, 'version.txt'), 'w+') as f:
+        f.write('sami2py v' + __version__ + '\n')
+        f.write('short hash ' + hash.decode("utf-8"))
 
-        shutil.copyfile(filelist[0], os.path.join(path, filelist[0]))
-        for list_file in filelist[1:]:
-            if clean:
-                shutil.move(list_file, os.path.join(path, list_file))
-            else:
-                shutil.copyfile(list_file, os.path.join(path, list_file))
-    else:
-        print('No files to move!')
+    shutil.copyfile(filelist[0], os.path.join(path, filelist[0]))
+    for list_file in filelist[1:]:
+        if clean:
+            shutil.move(list_file, os.path.join(path, list_file))
+        else:
+            shutil.copyfile(list_file, os.path.join(path, list_file))


### PR DESCRIPTION
# Description

Addresses #90 

Fixes the tab so that feedback is only given once.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import sami2py
sami2py.run_model(tag='run_name', lon=0, year=2012, day=213, dthr=0.25, hrinit=0., hrpr=0., hrmax=0.4)
```

In `develop`, the message "No files to move" is wrongly generated.  In this branch, not.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
