### PR TITLE
TST: Add flake8 tests to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 
 before_install:
   - pip install pytest-cov
+  - pip install pytest-flake8
   - pip install coveralls
   - pip install future
   - pip install pandas
@@ -29,7 +30,7 @@ before_script:
   - export DISPLAY=:99.0
 
 script:
-  - pytest -vs --cov=sami2py/
+  - pytest -vs --flake8 --cov=sami2py/
 
 after_success:
   - coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1] - 2020-04-13
+- Non-breaking changes
+  - Stylistic updates to conform to flake8
+- Testing changes
+  - Update Travis CI to use flake8 tests as part of CI
+
 ## [0.2.0] - 2019-12-17
 - API changes
   - Store loaded data in xarray object

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,20 +54,22 @@ To set up `sami2py` for local development:
 
    Now you can make your changes locally. Tests for new instruments are
    performed automatically.  Tests for custom functions should be added to the
-   appropriately named file in ``sami2py/tests``.   If no test file exists, then
-   you should create one.  This testing uses pytest, which will run tests on any
-   python file in the test directory that starts with ``test_``.
+   appropriately named file in ``sami2py/tests``.   If no test file exists,
+   then you should create one.  This testing uses pytest, which will run tests
+   on any python file in the test directory that starts with ``test_``.
 
 4. When you're done making changes, run all the checks to ensure that nothing
-   is broken on your local system
+   is broken on your local system.  You may need to install pytest and
+   pytest-flake8 first.
 
 ::
 
-    pytest -vs
+    pytest -vs --flake8
+
 
 5. Update/add documentation (in ``docs``), if relevant
 
-5. Commit your changes and push your branch to GitHub
+6. Commit your changes and push your branch to GitHub
 
 ::
 
@@ -75,7 +77,7 @@ To set up `sami2py` for local development:
     git commit -m "Brief description of your changes"
     git push origin name-of-your-bugfix-or-feature
 
-6. Submit a pull request through the GitHub website. Pull requests should be
+7. Submit a pull request through the GitHub website. Pull requests should be
    made to the ``develop`` branch.
 
 Pull Request Guidelines

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -115,8 +115,8 @@ class Model(object):
 
         out.append('\nComponent Models Used')
         out.append('---------------------')
-        out.append('Neutral Atmosphere: ' +
-                   self.MetaData['Neutral Atmosphere Model'])
+        out.append(' '.join(('Neutral Atmosphere:',
+                             self.MetaData['Neutral Atmosphere Model'])))
         out.append('Winds: ' + self.MetaData['Wind Model'])
         out.append('Photoproduction: ' + self.MetaData['EUV Model'])
         out.append('ExB Drifts: ' + self.MetaData['ExB model'])
@@ -145,8 +145,8 @@ class Model(object):
 
         local_time = np.mod((self.ut * 60 + self.lon0 * 4), 1440) / 60.0
         mean_anomaly = 2 * np.pi * self.day / 365.242
-        delta_t = (-7.657 * np.sin(mean_anomaly) +
-                   9.862 * np.sin(2 * mean_anomaly + 3.599))
+        delta_t = (-7.657 * np.sin(mean_anomaly)
+                   + 9.862 * np.sin(2 * mean_anomaly + 3.599))
         self.slt = local_time - delta_t / 60.0
 
     def _load_model(self):

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -198,7 +198,7 @@ class Model(object):
             zalt = get_unformatted_data(model_path, 'zalt')
 
             # Get plasma values
-            dim0 = nz*nf*ni + 2
+            dim0 = nz * nf * ni + 2
             dim1 = nt
             deni = get_unformatted_data(model_path, 'deni',
                                         dim=(dim0, dim1), reshape=True)
@@ -208,16 +208,16 @@ class Model(object):
                                       dim=(dim0, dim1), reshape=True)
 
             # Electron Temperatures have only one species
-            dim0 = nz*nf + 2
+            dim0 = nz * nf + 2
             te = get_unformatted_data(model_path, 'te',
                                       dim=(dim0, dim1), reshape=True)
             if self.outn:
                 # Multiple neutral species
-                dim0 = nz*nf*ni + 2
+                dim0 = nz * nf * ni + 2
                 denn = get_unformatted_data(model_path, 'denn',
                                             dim=(dim0, dim1), reshape=True)
                 # Only one wind
-                dim0 = nz*nf + 2
+                dim0 = nz * nf + 2
                 u4 = get_unformatted_data(model_path, 'u4',
                                           dim=(dim0, dim1), reshape=True)
 

--- a/sami2py/tests/test_utils.py
+++ b/sami2py/tests/test_utils.py
@@ -105,7 +105,7 @@ class TestGetUnformattedData():
         """Test a successful get of unformatted data with the reshape flag
         set to True
         """
-        dim0 = 98*101*7 + 2  # nf*nz*ni + 2
+        dim0 = 98 * 101 * 7 + 2  # nf*nz*ni + 2
         dim1 = 2             # nt
         ret_data = sami2py.utils.get_unformatted_data(self.model_pathU, 'deni',
                                                       dim=(dim0, dim1),

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,8 @@ install_requires =
   xarray
   matplotlib
 scripts =
+
+[tool:pytest]
+flake8-ignore =
+  *.py W503
+  docs/conf.py ALL


### PR DESCRIPTION
# Description

Uses pytest-flake8 to do a flake check on all code on Travis CI.  Updates whitespace and linebreaks to match flake8 conventions.  Travis CI unit tests will now error if flake8 violations are found.  Not checked in Appveyor as this should be platform-independent.

Note: W503 and W504 are mutually exclusive, but both are checked for in pytest-flake8.  W503 is ignored as this is inconsistent with PEP8.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Via Travis CI.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

