### PR TITLE
TST: NEP 029 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
+os: linux
 language: python
 dist: xenial
-matrix:
+jobs:
   include:
+    - name: Minimum NEP 029 versions
+      python: 3.6
+      env: NUMPY_VER=1.15
+    # Versions with latest numpy
     - python: 3.6
     - python: 3.7
     - python: 3.8
@@ -14,6 +19,11 @@ addons:
     - gfortran
 
 before_install:
+  - if [ -z ${NUMPY_VER} ]; then
+      echo 'Using latest numpy';
+    else
+      pip install -q numpy==$NUMPY_VER;
+    fi
   - pip install pytest-cov
   - pip install coveralls
   - pip install future

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
-  - pip install pandas
-  - pip install xarray
-  - pip install matplotlib
 
 install:
   - python setup.py install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1] - 2020-04-13
+- Testing changes
+  - Update Travis CI to test for numpy versions as in NEP 029
+
 ## [0.2.0] - 2019-12-17
 - API changes
   - Store loaded data in xarray object


### PR DESCRIPTION
# Description

Adds a test configuration to Travis CI to run NEP 029 recommended minimum support case with Python 3.6 and numpy 1.15.  Also removes manual pip installs of pandas, xarray, matplotlib required for python 3.5 testing.

## Type of change

- Test environment update (non-breaking change which adds functionality)

# How Has This Been Tested?

Updates to Travis CI env, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

