### PR TITLE
TST: update travis test environment  -- numpy version, avoid matplotlib pre-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ addons:
 
 before_install:
   - if [ -z ${NUMPY_VER} ]; then
-      echo 'Using latest numpy';
+      # Make sure travis uses latest numpy, not pre-installed version
+      pip upgrade numpy
     else
       pip install -q numpy==$NUMPY_VER;
     fi
+  - pip install "matplotlib<3.3"  # FIXME: matplotlib 3.3. pre-release not compatible with numpy 1.15
   - pip install pytest-cov
   - pip install pytest-flake8
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 before_install:
   - if [ -z ${NUMPY_VER} ]; then
       # Make sure travis uses latest numpy, not pre-installed version
-      pip upgrade numpy
+      pip install -q numpy upgrade
     else
       pip install -q numpy==$NUMPY_VER;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 before_install:
   - if [ -z ${NUMPY_VER} ]; then
       # Make sure travis uses latest numpy, not pre-installed version
-      pip install -q numpy upgrade
+      pip install -q numpy --upgrade
     else
       pip install -q numpy==$NUMPY_VER;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
       pip install -q numpy==$NUMPY_VER;
     fi
   # FIXME: matplotlib 3.3. pre-release not compatible with numpy 1.15
-  - pip install "matplotlib<3.3"  
+  - pip install "matplotlib<3.3"
   - pip install pytest-cov
   - pip install pytest-flake8
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_install:
     else
       pip install -q numpy==$NUMPY_VER;
     fi
-  # FIXME: matplotlib 3.3. pre-release not compatible with numpy 1.15
   - pip install "matplotlib<3.3"
+  # matplotlib 3.3. pre-release not compatible with numpy 1.15
   - pip install pytest-cov
   - pip install pytest-flake8
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 before_install:
   - if [ -z ${NUMPY_VER} ]; then
       # Make sure travis uses latest numpy, not pre-installed version
-      pip install -q numpy --upgrade
+      pip install -q numpy --upgrade;
     else
       pip install -q numpy==$NUMPY_VER;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,15 @@ addons:
     - gfortran
 
 before_install:
+  # Unless version is specified, make sure travis uses latest numpy,
+  # not pre-installed version
   - if [ -z ${NUMPY_VER} ]; then
-      # Make sure travis uses latest numpy, not pre-installed version
       pip install -q numpy --upgrade;
     else
       pip install -q numpy==$NUMPY_VER;
     fi
-  - pip install "matplotlib<3.3"
   # matplotlib 3.3. pre-release not compatible with numpy 1.15
+  - pip install "matplotlib<3.3"
   - pip install pytest-cov
   - pip install pytest-flake8
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ before_install:
     else
       pip install -q numpy==$NUMPY_VER;
     fi
-  - pip install "matplotlib<3.3"  # FIXME: matplotlib 3.3. pre-release not compatible with numpy 1.15
+  # FIXME: matplotlib 3.3. pre-release not compatible with numpy 1.15
+  - pip install "matplotlib<3.3"  
   - pip install pytest-cov
   - pip install pytest-flake8
   - pip install coveralls


### PR DESCRIPTION
# Description

matplotlib 3.3.0rc1 and numpy 1.15 do not play well together.  Putting a cap on travis env to avoid this version for now.

Also, uses `pip upgrade` to make sure latest version of numpy is installed for python 3.7 tests.

## Type of change

- Testing env fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Changes to travis env, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes

