### PR TITLE
TST: update to numpy 1.16 as minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   include:
     - name: Minimum NEP 029 versions
       python: 3.6
-      env: NUMPY_VER=1.15
+      env: NUMPY_VER=1.16
     # Versions with latest numpy
     - python: 3.6
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,10 @@ addons:
 before_install:
   # Unless version is specified, make sure travis uses latest numpy,
   # not pre-installed version
-  # Latest releases of cftime, etc, not compatible with numpy 1.15
   - if [ -z ${NUMPY_VER} ]; then
       pip install -q numpy --upgrade;
     else
       pip install -q numpy==$NUMPY_VER;
-      pip install "cftime<1.1";
-      pip install "netCDF4<1.5.3";
-      pip install "matplotlib<3.3";
     fi
   - pip install pytest-cov
   - pip install pytest-flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [next version] - 2020-07-27
+- Using numpy 1.16 as minimum test version in accordance with NEP 29
+
 ## [0.2.2] - 2020-07-17
 - Added simple port of core data to netcdf file
 - Increased unformatted test data to 6 time steps


### PR DESCRIPTION
# Description

July 23 has come and gone, and pandas dropped numpy 1.15 support like that.  Since it's no longer required, we'll do the same here.

Prompted by failure of cron batch job for main branch:  https://travis-ci.com/github/sami2py/sami2py

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

updates to travis env, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes

