### PR TITLE
added default exb file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.o
 *.x
 *.mod
-sami2py/fortran/ExB.inp
+sami2py/fortran/exb.inp
 sami2py/fortran/sami2py-1.00.namelist
 
 .DS_STORE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - return_fourier function in utils.py 
   - plot_exb function in _core_class.py
   - Testing return_fourier function in test_utils.py
+- added default exb file: setup.py generates a exb.inp file
 
 ## [0.2.2] - 2020-07-17
 - Added simple port of core data to netcdf file

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ fortran_path = os.path.join(here, 'sami2py', 'fortran')
 test_data_path = os.path.join(here, 'sami2py', 'tests', 'test_data')
 # generate path to store test and fortran file paths
 file_path = os.path.join(home_dir, '.sami2py', env_name)
+# generate path to ExB coefficients
+exb_path = os.path.join(fortran_path, 'exb.inp')
 
 # %% build
 
@@ -43,6 +45,11 @@ if not os.path.isfile(os.path.join(fortran_path, 'sami2py.x')):
 if not os.path.isdir(file_path):
     os.makedirs(file_path)
     print('Created {} directory to store settings.'.format(file_path))
+
+if not os.path.isfile(exb_path):
+    zero_list = ["0 0"] * 10
+    with open(exb_path, 'w') as exb:
+        exb.writelines("%s\n" % line for line in zero_list)
 
 with open(os.path.join(file_path, 'fortran_path.txt'), 'w+') as f:
     f.write(fortran_path)


### PR DESCRIPTION
added default exb file: setup.py generates a exb.inp file.
Also changed gitignore to reflect the case of the file sami2py.x references while simultaneously not tracking the changes to exb.inp.
This could be done the other way, where the fortran is changed.

# Description

Addresses #129 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Followed the install and examples in the docs, 
- ran pytest locally.

**Test Configuration**:
* Debian 10.1
* Python 3.8.5
* Virtual machine, conda environment

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``main``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes

