### PR TITLE
BUG: repr with a float longitude

### DIFF
--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -38,7 +38,7 @@ class Model(object):
         ----------
         tag : (string)
             name of run (top-level directory)
-        lon : (int)
+        lon : (float)
             longitude reference
         year : (int)
             year

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -106,7 +106,7 @@ class Model(object):
         out.append('Model Run Name = ' + self.tag)
         out.append(('Day {day:03d}, {year:4d}').format(day=self.day,
                                                        year=self.year))
-        out.append(('Longitude = {lon:d} deg').format(lon=self.lon0))
+        out.append(('Longitude = {lon:5.1f} deg').format(lon=self.lon0))
         temp_str = '{N:d} time steps from {t0:4.1f} to {tf:4.1f} UT'
         out.append(temp_str.format(N=len(self.ut),
                                    t0=min(self.ut),

--- a/sami2py/tests/test_core_class.py
+++ b/sami2py/tests/test_core_class.py
@@ -18,7 +18,7 @@ class TestModelObject():
         """
         self.tmp_archive_dir = sami2py.archive_dir
         sami2py.utils.set_archive_dir(path=sami2py.test_data_dir)
-        self.lon = 256
+        self.lon = 256.1
         self.year = 1999
         self.day = 256
 
@@ -123,7 +123,7 @@ class TestModelPlot():
         """
         self.tmp_archive_dir = sami2py.archive_dir
         sami2py.utils.set_archive_dir(path=sami2py.test_data_dir)
-        self.lon = 256
+        self.lon = 256.1
         self.year = 1999
         self.day = 257
         self.model = sami2py.Model(tag='test', lon=self.lon, year=self.year,

--- a/sami2py/tests/test_core_class.py
+++ b/sami2py/tests/test_core_class.py
@@ -98,7 +98,7 @@ class TestModelObjectUnformatted(TestModelObject):
         """
         self.tmp_archive_dir = sami2py.archive_dir
         sami2py.utils.set_archive_dir(path=sami2py.test_data_dir)
-        self.lon = 256
+        self.lon = 256.1
         self.year = 1999
         self.day = 257
 


### PR DESCRIPTION
# Description

Missed this in #135.  The core model class `repr` needs to be updated as well for float longitudes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Generate a model run for a specific lcoation
```
loc = {'lat': -11.9523, 'lon': -76.8758, 'tag': 'sw_test'}
sami2py.run_model(tag=loc['tag'], lat=loc['lat'], lon=loc['lon'], year=2012, day=1)
ModelRun = sami2py.Model(tag=loc['tag'], lon=loc['lon'], year=2012, day=1)
```
Then run `ModelRun` to invoke the repr routine.

**Test Configuration**:
* Mac OS X 10.15.7
* python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [na] Add a note to ``CHANGELOG.md``, summarizing the changes

