### PR TITLE
STY: flake8 configuration and line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 132
-exclude = .git,__pycache__,.eggs/,doc/,docs/,build/,dist/,archive/

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -401,8 +401,8 @@ class Model(object):
     def plot_lat_alt(self, time_step=0, species=1):
         """Plots input parameter as a function of latitude and altitude
 
-        .. deprecated:: 0.3.0
-          All plotting routines will be removed in 0.4.0 and moved to
+        .. deprecated:: 0.2.0
+          All plotting routines will be removed in 0.3.0 and moved to
           sami2py_vis
 
         Parameters
@@ -425,7 +425,7 @@ class Model(object):
         """
 
         warnings.warn(' '.join(["Model.plot_lat_alt is deprecated and will be",
-                                "removed in a future version. ",
+                                "removed in version 0.3.0. ",
                                 "Use sami2py_vis instead"]),
                       DeprecationWarning)
 
@@ -440,7 +440,7 @@ class Model(object):
     def plot_exb(self):
         """Plots ExB drifts from the return_fourier function
 
-        .. deprecated:: 0.3.0
+        .. deprecated:: 0.2.3
           All plotting routines will be removed in 0.4.0 and moved to
           sami2py_vis
 
@@ -454,7 +454,7 @@ class Model(object):
         """
 
         warnings.warn(' '.join(["Model.plot_exb is deprecated and will be",
-                                "removed in a future version. ",
+                                "removed in a 0.3.0. ",
                                 "Use sami2py_vis instead"]),
                       DeprecationWarning)
 

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -454,7 +454,7 @@ class Model(object):
         """
 
         warnings.warn(' '.join(["Model.plot_exb is deprecated and will be",
-                                "removed in a 0.3.0. ",
+                                "removed in version 0.3.0. ",
                                 "Use sami2py_vis instead"]),
                       DeprecationWarning)
 

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -176,4 +176,4 @@ class TestDriftGeneration():
 
     def test_bad_string(self):
         with pytest.raises(Exception):
-            sami2py._core._generate_drift_info(False, 'really_cool_drifts_probably')
+            sami2py._core._generate_drift_info(False, 'really_cool_drifts')

--- a/sami2py/tests/test_utils.py
+++ b/sami2py/tests/test_utils.py
@@ -192,7 +192,8 @@ class TestFourierFit():
         """Test that the warning is generated properly"""
         nan_drifts = np.array([np.nan])
         with pytest.warns(Warning):
-            v0, fit_coefs, cov = sami2py.utils.fourier_fit(self.lt, nan_drifts, 10)
+            v0, fit_coefs, cov = sami2py.utils.fourier_fit(self.lt, nan_drifts,
+                                                           10)
             assert v0 == 0
             assert (fit_coefs == np.zeros((10, 2))).all()
             assert (cov == np.zeros((10, 2))).all()

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,5 +42,6 @@ install_requires =
 scripts =
 
 [flake8]
+max-line-length=80
 ignore =
   W503


### PR DESCRIPTION
# Description

Adjusts the configuration to more closely match pysat standards.
- Moves flake8 settings to setup.cfg
- Sets max line length to 80
- adjusts code style to match this
- adjusts deprecation docstrings and warnings to match roadmap

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running flake8 locally

**Test Configuration**:
* Mac OS X 10.15.7
* python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

