### PR TITLE
Updates netCDF4 file for pysatModels with latest standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.3] - 2021-05-31
-- Updated Variable and datasest attributes for netcdf export
-- Added default drift fourier coefficient array accessable from run model
+- Updated Variable and dataset attributes for netcdf export
+  - Updated netcdf file in test_data
+- Added default drift fourier coefficient array accessible from run model
 - Using minimum test version of numpy in accordance with NEP 29
 - Removed the sami2py-1.00.namelist and version.txt files from run_name
 - Bug Fix

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ sami2py: sami2py is another model of the ionosphere python style
     :stub-columns: 1
 
     * - docs
-      - | |docs| |doi|
+      - | |rtd| |doi|
     * - tests
       - | |pytest|
         | |coveralls| |codecov|

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -405,11 +405,10 @@ class Model(object):
         attrs = {}
         keys = self.MetaData.keys()
         for key in keys:
-            new_key = key.replace(' ', '_')
-            new_key = new_key.replace('.', '_')
+            new_key = key.replace(' ', '_').replace('.', '_')
             attrs[new_key] = self.MetaData[key]
         attrs['fmtout'] = str(attrs['fmtout'])
-        if attrs['ExB_model'] == 'Fourier_Series':
+        if attrs['ExB_model'] == 'Fourier Series':
             attrs['Fourier_Coeffs'] = str(attrs['Fourier_Coeffs'])
 
         self.data.attrs = attrs

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -253,10 +253,22 @@ class Model(object):
                                 'slt': (['ut'], self.slt,
                                         {'units': 'hrs',
                                          'long_name': 'solar local time'})},
-                               coords={'glat': (['z', 'f'], glat),
-                                       'glon': (['z', 'f'], glon),
-                                       'zalt': (['z', 'f'], zalt),
-                                       'ut': self.ut})
+                               coords={'glat': (['z', 'f'], glat,
+                                                {'units': 'deg',
+                                                 'long_name': 'Geo Latitude',
+                                                 'value_min': -90.0,
+                                                 'value_max': 90.0}),
+                                       'glon': (['z', 'f'], glon,
+                                                {'units': 'deg',
+                                                 'long_name': 'Geo Longitude',
+                                                 'value_min': 0.0,
+                                                 'value_max': 360.0}),
+                                       'zalt': (['z', 'f'], zalt,
+                                                {'units': 'km',
+                                                 'long_name': 'Altitude'}),
+                                       'ut': (['ut'], self.ut,
+                                              {'units': 'hours',
+                                               'long_name': 'Universal Time'})})
         if self.outn:
             denn = np.reshape(denn, (nz, nf, ni, nt), order="F")
             self.data['denn'] = (('z', 'f', 'ion', 'ut'), denn,

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -402,10 +402,15 @@ class Model(object):
         """saves core data as a netcdf file"""
         if path == '':
             path = 'sami2py_output.nc'
-        attrs = self.MetaData
+        attrs = {}
+        keys = self.MetaData.keys()
+        for key in keys:
+            new_key = key.replace(' ', '_')
+            new_key = new_key.replace('.', '_')
+            attrs[new_key] = self.MetaData[key]
         attrs['fmtout'] = str(attrs['fmtout'])
-        if attrs['ExB model'] == 'Fourier Series':
-            attrs['Fourier Coeffs'] = str(attrs['Fourier Coeffs'])
+        if attrs['ExB_model'] == 'Fourier_Series':
+            attrs['Fourier_Coeffs'] = str(attrs['Fourier_Coeffs'])
 
         self.data.attrs = attrs
         self.data.to_netcdf(path=path, format='NETCDF4')

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ classifiers =
   Programming Language :: Python :: 3.7
   Operating System :: OS Independent
 license_file = License.md
-long_description = file: README.md
-long_description_content_type = text/markdown
+long_description = file: README.rst
+long_description_content_type = text/x-rst
 
 [options]
 python_requires = >= 3.5


### PR DESCRIPTION
# Description

Updates the test file used for testing `pysatModels` with the metadata-enhanced version.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Assuming pysatModels is installed and registered, navigate to Line 211 in the sami2py instrument (sami2py_sami2.py):

https://github.com/pysat/pysatModels/blob/9c91d9df0cc221b47cc21948f0d3df9411486367/pysatModels/models/sami2py_sami2.py#L211

Change "main" to "pysatmodels" so that your local code will download from this branch instead of the main branch.  
In python:
```
import datetime as dt
import pysat
sami2 = pysat.Instrument('sami2py', 'sami2', tag='test')
sami2.download(dt.datetime(2019, 1, 1))
sami2.load(2019, 1)
```

Inspect `sami2.meta` to confirm that units and long_name are present.

**Test Configuration**:
* Mac OS X 10.15.7
* python 3.8.2

# Notes:
Metadata will be expanded in 3.0.0.  Full issue at #137.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch -- for the new release!
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

