### PR TITLE
STY: deprecate non-snake_case  keywords

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,21 +28,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install latest dependencies
-      if: ${{ matrix.numpy_ver == 'latest'}}
+    - name: Install standard dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r test_requirements.txt
         pip install -r requirements.txt
-        pip install numpy --upgrade;
+        pip install -r test_requirements.txt
 
     - name: Install NEP29 dependencies
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
-        python -m pip install --upgrade pip
-        pip install -r test_requirements.txt
-        pip install -r requirements.txt
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }};
+        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Reinstall fortran on MacOS
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
         pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
+        # Latest xarray not compatible with numpy 1.20
+        pip install xarray<=2022.3.0
 
     - name: Reinstall fortran on MacOS
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
         # Latest xarray not compatible with numpy 1.20
-        pip install xarray<=2022.3.0
+        pip install xarray==2022.3
 
     - name: Reinstall fortran on MacOS
       if: ${{ matrix.os == 'macos-latest' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * Implement flake8-docstring and hacking packages to lint code
   * Update docstring standards
   * Updated NEP 29 compliance in CI tests
+  * Deprecated camel case keys in `run_model`
 
 ## [0.2.5] - 2021-10-19
 * Add basic metadata for ExB Fourier Coefficients

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -102,7 +102,7 @@ class TestBasicModelRun(object):
 
         return
 
-    def test_run_model_ExB_wrong_size(self):
+    def test_run_model_exb_wrong_size(self):
         """Test that the ExB has proper shape."""
 
         with pytest.raises(Exception):

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -234,10 +234,22 @@ class TestDeprecation(object):
                                         test=True)
         if not os.path.exists(self.model_path):
             os.makedirs(self.model_path)
+
+        # Set tmp directory
+        self.tmp_archive_dir = sami2py.archive_dir
+        sami2py.utils.set_archive_dir(path=test_data_dir)
+
         return
 
     def teardown(self):
         """Clean up the unit test environment after each method."""
+
+        if os.path.isdir(self.tmp_archive_dir):
+            sami2py.utils.set_archive_dir(path=self.tmp_archive_dir)
+        else:
+            with open(sami2py._archive_path, 'w') as archive_file:
+                archive_file.write('')
+                sami2py.archive_dir = ''
 
         return
 

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -92,12 +92,12 @@ class TestBasicModelRun(object):
 
         return
 
-    def test_run_model_ExB_files(self):
+    def test_run_model_exb_files(self):
         """Test that the ExB files are copied properly."""
 
         sami2py.run_model(tag='test', lon=0, year=2012, day=211, test=True,
                           fmtout=self.format,
-                          fejer=False, ExB_drifts=np.zeros((10, 2)))
+                          fejer=False, exb_drifts=np.zeros((10, 2)))
         assert os.stat(os.path.join(self.model_path, 'exb.inp'))
 
         return
@@ -108,7 +108,7 @@ class TestBasicModelRun(object):
         with pytest.raises(Exception):
             sami2py.run_model(year=2012, day=211, test=True,
                               fmtout=self.format, fejer=False,
-                              ExB_drifts=np.zeros((1, 2)))
+                              exb_drifts=np.zeros((1, 2)))
 
         return
 

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -229,6 +229,11 @@ class TestDeprecation(object):
         """Set up the unit test environment for each method."""
 
         warnings.simplefilter("always", DeprecationWarning)
+
+        self.model_path = generate_path(tag='test', lon=0, year=2012, day=211,
+                                        test=True)
+        if not os.path.exists(self.model_path):
+            os.makedirs(self.model_path)
         return
 
     def teardown(self):
@@ -255,7 +260,7 @@ class TestDeprecation(object):
         with warnings.catch_warnings(record=True) as war:
             # Using minimum runtime since the check has occurred before
             # sami2 executable is run
-            sami2py.run_model(hrmax=0.0, **kwargs)
+            sami2py.run_model(tag='test', hrmax=0.0, **kwargs)
 
         warn_msg = "keyword `{:}` is deprecated".format(key)
         msg_found = []
@@ -273,5 +278,5 @@ class TestDeprecation(object):
         with pytest.raises(KeyError):
             # Using minimum runtime since the check has occurred before
             # sami2 executable is run
-            sami2py.run_model(hrmax=0.0, dinosaur=True)
+            sami2py.run_model(tag='test', hrmax=0.0, dinosaur=True)
         return

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -3,6 +3,7 @@
 import numpy as np
 import os
 import shutil
+import warnings
 
 import pytest
 
@@ -218,4 +219,59 @@ class TestDriftGeneration(object):
         with pytest.raises(Exception):
             sami2py._core._generate_drift_info(False, 'really_cool_drifts')
 
+        return
+
+
+class TestDeprecation(object):
+    """Unit test for deprecation warnings."""
+
+    def setup(self):
+        """Set up the unit test environment for each method."""
+
+        warnings.simplefilter("always", DeprecationWarning)
+        return
+
+    def teardown(self):
+        """Clean up the unit test environment after each method."""
+
+        return
+
+    @pytest.mark.parametrize("key", ['ExB_drifts', 'Tinf_scale', 'Tn_scale'])
+    def test_key_deprecation(self, key):
+        """Check that camel case variables are deprecated.
+
+        parameters
+        ----------
+        key : str
+            Name of deprecated key
+
+        """
+
+        dep_keys = {'ExB_drifts': np.ones((10, 2)),
+                    'Tinf_scale': 0.75,
+                    'Tn_scale': 0.75}
+        kwargs = {key: dep_keys[key]}
+
+        with warnings.catch_warnings(record=True) as war:
+            # Using minimum runtime since the check has occurred before
+            # sami2 executable is run
+            sami2py.run_model(hrmax=0.0, **kwargs)
+
+        warn_msg = "keyword `{:}` is deprecated".format(key)
+        msg_found = []
+        for item in war:
+            msg_found.append(warn_msg in str(item.message))
+
+        # Check that desired warning appears in list of warnings
+        assert np.any(msg_found)
+
+        return
+
+    def test_key_error(self):
+        """Test that invalid keys error for the deprecated keyword handler."""
+
+        with pytest.raises(KeyError):
+            # Using minimum runtime since the check has occurred before
+            # sami2 executable is run
+            sami2py.run_model(hrmax=0.0, dinosaur=True)
         return


### PR DESCRIPTION
# Description

Addresses #150

Some fo the keywords for the core class are not snake case.  This updates that, as well as scans for old usage to throw a deprecation warning.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

Usage of old kwargs should throw a deprecation warning
```
import sami2py
sami2py.run_model(tag='test', hrmax=0.0, Tinf_scale=0.7)
```

Uasge of new kwargs will run as expected
```
import sami2py
sami2py.run_model(tag='test', hrmax=0.0, tinf_scale=0.7)
```

Using hrmax=0 keeps the run to a minimum.  The namelist can be inspected to ensure the kwargs are passed through correctly.

**Test Configuration**:
* Mac OS X Big Sur
* Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

