### PR TITLE
TST: nep29

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install standard dependencies
+      if: ${{ matrix.numpy_ver == 'latest'}}
       run: |
         pip install -r requirements.txt
         pip install -r test_requirements.txt
@@ -36,9 +37,8 @@ jobs:
     - name: Install NEP29 dependencies
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
-        # Latest xarray not compatible with numpy 1.20
-        pip install xarray==2022.3
+        pip install -r requirements_nep29.txt
+        pip install -r test_requirements.txt
 
     - name: Reinstall fortran on MacOS
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,17 +28,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install requirements for testing setup
+      run: |
+        pip install -r test_requirements.txt
+
     - name: Install standard dependencies
       if: ${{ matrix.numpy_ver == 'latest'}}
       run: |
         pip install -r requirements.txt
-        pip install -r test_requirements.txt
 
     - name: Install NEP29 dependencies
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
         pip install -r requirements_nep29.txt
-        pip install -r test_requirements.txt
 
     - name: Reinstall fortran on MacOS
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.20"
+            numpy_ver: "nep029"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/requirements_nep29.txt
+++ b/requirements_nep29.txt
@@ -1,0 +1,5 @@
+netCDF4
+numpy==1.20
+pandas
+scipy
+xarray


### PR DESCRIPTION
# Description

Looking through old logs, the nep29 install has been inconsistent in installation.  Some jobs will reinstall the latest numpy rather than the minimum version during the pandas install.

This change
- Makes the nep29 install a separate module, rather than an additional module, in the main workflow
- Adds a requirements_nep29 file, which pins the numpy version.  A numpy version is no longer required in the main workflow
- Lets pip handle version conflicts, rather than the user
- Cleans up the style by having test requirements as a separate module

The core packages installed in GA are in the table below:

| package | standard |  nep29 |
| --- | --- | --- |
| netCDF4 | 1.6.1 | 1.6.1 | 
| numpy | 1.23.4  | 1.20.0 |
| pandas | 1.5.1  | 1.4.4 |
| scipy | 1.9.3 | 1.9.3 |
| xarray | 2022.10.0 | 2022.10.0 |

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Inspection of Github Actions environment

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [na] Add a note to ``CHANGELOG.md``, summarizing the changes *(Previous changelog line about fixing nep29 applies)*

