### PR TITLE
MAINT: pytest deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * Deprecated camel case keys in `run_model`
   * Remove deprecated plotting functions (moved to `sami2py_vis`)
   * Improved discussion of fortran compiler requirements in docs
+  * Removed deprecated pytest functions
 
 ## [0.2.5] - 2021-10-19
 * Add basic metadata for ExB Fourier Coefficients

--- a/sami2py/_core.py
+++ b/sami2py/_core.py
@@ -3,33 +3,7 @@
 # Copyright (C) 2017, JK & JH
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
-"""Wrapper for running sami2 model.
-
-Functions
--------------------------------------------------------------------------------
-
-run_model(tag='model_run', lat=0, lon=0, alt=300, year=2018, day=1,
-          f107=120, f107a=120, ap=0,
-          rmin=100, rmax=2000, gams=3, gamp=3, altmin=85.,
-          dthr=0.25, hrinit=0., hrpr=24., hrmax=48.,
-          dt0=30., maxstep=100000000, denmin=1.e-6,
-          nion1=1, nion2=7, mmass=48, h_scale=1, o_scale=1,
-          no_scale=1, o2_scale=1, he_scale=1, n2_scale=1, n_scale=1,
-          tinf_scale=1, tn_scale=1., euv_scale=1,
-          wind_scale=1, hwm_model=14,
-          fejer=True, exb_drifts=np.zeros((10, 2)), ve01=0., exb_scale=1,
-          alt_crit=150., cqe=7.e-14,
-          clean=False, test=False, fmtout=True, outn=False)
-
-    Initializes a run of the SAMI2 model and archives the data.
--------------------------------------------------------------------------------
-
-Moduleauthor
--------------------------------------------------------------------------------
-Jeff Klenzing (JK), 1 Dec 2017, Goddard Space Flight Center (GSFC)
--------------------------------------------------------------------------------
-
-"""
+"""Methods for running and archiving the results of SAMI2."""
 
 import numpy as np
 import os

--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -3,15 +3,7 @@
 # Copyright (C) 2017, JK & JH
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
-"""Wrapper for running sami2 model.
-
-Classes
--------
-Model
-    Loads, reshapes, and holds SAMI2 output for a given model run
-    specified by the user.
-
-"""
+"""Class to load, reshape, and manage SAMI2 output."""
 
 import numpy as np
 from os import path

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -46,7 +46,7 @@ class TestBasicModelRun(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         for filename in self.filelist:
@@ -165,7 +165,7 @@ class TestBasicModelRunUnformatted(TestBasicModelRun):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         for filename in self.filelist:
@@ -186,7 +186,7 @@ class TestDriftGeneration(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         os.remove('exb.inp')
@@ -242,7 +242,7 @@ class TestDeprecation(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         if os.path.isdir(self.tmp_archive_dir):

--- a/sami2py/tests/test_core.py
+++ b/sami2py/tests/test_core.py
@@ -29,7 +29,7 @@ def cmp_lines(path_1, path_2):
 class TestBasicModelRun(object):
     """Basic tests of the run_model script."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         self.format = True
@@ -148,7 +148,7 @@ class TestBasicModelRun(object):
 class TestBasicModelRunUnformatted(TestBasicModelRun):
     """Basic tests of the run_model script w/ unformatted output."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         self.format = False
@@ -178,7 +178,7 @@ class TestBasicModelRunUnformatted(TestBasicModelRun):
 class TestDriftGeneration(object):
     """Tests for the _core function _generate_drift_info."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         f = open('exb.inp', 'w')
@@ -226,7 +226,7 @@ class TestDriftGeneration(object):
 class TestDeprecation(object):
     """Unit test for deprecation warnings."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         warnings.simplefilter("always", DeprecationWarning)

--- a/sami2py/tests/test_core_class.py
+++ b/sami2py/tests/test_core_class.py
@@ -11,7 +11,7 @@ import sami2py
 class TestModelObject(object):
     """Test basic model object functionality."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         self.tmp_archive_dir = sami2py.archive_dir
@@ -110,7 +110,7 @@ class TestModelObject(object):
 class TestModelObjectUnformatted(TestModelObject):
     """Test basic model object functionality."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         self.tmp_archive_dir = sami2py.archive_dir

--- a/sami2py/tests/test_core_class.py
+++ b/sami2py/tests/test_core_class.py
@@ -22,7 +22,7 @@ class TestModelObject(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         if os.path.isdir(self.tmp_archive_dir):
@@ -121,7 +121,7 @@ class TestModelObjectUnformatted(TestModelObject):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         if os.path.isdir(self.tmp_archive_dir):

--- a/sami2py/tests/test_utils.py
+++ b/sami2py/tests/test_utils.py
@@ -14,14 +14,14 @@ import sami2py
 class TestGeneratePath(object):
     """Test basic functionality of the generate_path function."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         sami2py.archive_dir = 'test'
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         return
@@ -113,7 +113,7 @@ class TestArchiveDir(object):
 class TestGetUnformattedData(object):
     """Test basic functionality of the get_unformatted_data function."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         self.model_f_path = sami2py.utils.generate_path('test', 256, 1999, 256,
@@ -123,7 +123,7 @@ class TestGetUnformattedData(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         del self.model_f_path, self.model_u_path
@@ -178,7 +178,7 @@ class TestGetUnformattedData(object):
 class TestFourierFunction(object):
     """Test basic functionality of the return_fourier function."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
         self.x = np.array([0.11, 0.36, 0.61, 0.86, 1.12, 1.37, 1.62, 1.88,
                            2.13, 2.38, 2.64, 2.89, 3.14, 3.4, 3.65, 3.9,
@@ -198,7 +198,7 @@ class TestFourierFunction(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         del self.x, self.coeffs
@@ -231,7 +231,7 @@ class TestFourierFunction(object):
 class TestFourierFit(object):
     """Test basic functionality of the fourier fitting function."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
 
         self.lt = np.linspace(0, 24, 49)
@@ -241,7 +241,7 @@ class TestFourierFit(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the test env after each method."""
 
         del self.lt, self.coeffs, self.v


### PR DESCRIPTION
# Description

pytest is deprecating nose-syntax.  This updates the setup and teardown statements accordingly.  See https://github.com/pysat/pysat/issues/1053

Also cleans up some docstrings

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

running unit tests

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

